### PR TITLE
Handle notion.site API base 406 fallback

### DIFF
--- a/blog.config.js
+++ b/blog.config.js
@@ -1,7 +1,7 @@
 // 注: process.env.XX是Vercel的环境变量，配置方式见：https://docs.tangly1024.com/article/how-to-config-notion-next#c4768010ae7d44609b744e79e2f9959a
 
 const BLOG = {
-  API_BASE_URL: process.env.API_BASE_URL || 'https://www.notion.so/api/v3', // API默认请求地址,可以配置成自己的地址例如：https://[xxxxx].notion.site/api/v3
+  API_BASE_URL: process.env.API_BASE_URL || 'https://www.notion.so/api/v3', // API默认请求地址，避免使用 https://[xxxxx].notion.site/api/v3 以防 Notion 返回 406
   // Important page_id！！！Duplicate Template from  https://tanghh.notion.site/02ab3b8678004aa69e9e415905ef32a5
   NOTION_PAGE_ID:
     process.env.NOTION_PAGE_ID ||

--- a/lib/notion/getNotionAPI.js
+++ b/lib/notion/getNotionAPI.js
@@ -1,23 +1,46 @@
 import { NotionAPI as NotionLibrary } from 'notion-client'
 import BLOG from '@/blog.config'
 
+const DEFAULT_API_BASE_URL = 'https://www.notion.so/api/v3'
+
 const notionAPI = getNotionAPI()
+
+function sanitizeApiBaseUrl(rawUrl) {
+  const apiBaseUrl = (rawUrl || '').toString().trim()
+
+  if (!apiBaseUrl) {
+    return DEFAULT_API_BASE_URL
+  }
+
+  // Notion now rejects collection queries against workspace vanity domains.
+  if (apiBaseUrl.includes('.notion.site')) {
+    console.warn(
+      '[Notion API] Detected notion.site API host, falling back to https://www.notion.so/api/v3 to avoid 406 responses.'
+    )
+    return DEFAULT_API_BASE_URL
+  }
+
+  return apiBaseUrl.endsWith('/') ? apiBaseUrl.slice(0, -1) : apiBaseUrl
+}
 
 function getNotionAPI() {
   return new NotionLibrary({
-    apiBaseUrl: BLOG.API_BASE_URL || 'https://www.notion.so/api/v3', // https://[xxxxx].notion.site/api/v3
+    apiBaseUrl: sanitizeApiBaseUrl(BLOG.API_BASE_URL), // https://[xxxxx].notion.site/api/v3
     activeUser: BLOG.NOTION_ACTIVE_USER || null,
     authToken: BLOG.NOTION_TOKEN_V2 || null,
     userTimeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    kyOptions: { 
-      mode:'cors',
+    kyOptions: {
+      mode: 'cors',
       hooks: {
         beforeRequest: [
-          (request) => {
+          request => {
             const url = request.url.toString()
             if (url.includes('/api/v3/syncRecordValues')) {
               return new Request(
-                url.replace('/api/v3/syncRecordValues', '/api/v3/syncRecordValuesMain'),
+                url.replace(
+                  '/api/v3/syncRecordValues',
+                  '/api/v3/syncRecordValuesMain'
+                ),
                 request
               )
             }


### PR DESCRIPTION
## Summary
- sanitize the configured Notion API base URL and fall back to https://www.notion.so/api/v3 when a notion.site host is provided to avoid 406 errors on collection queries
- update the API_BASE_URL configuration comment to steer deployments away from notion.site endpoints

## Testing
- npm run lint *(fails: existing lint warnings/errors in unrelated files, e.g., await-thenable in pages/api/cache.js)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cd1eee460832e87414895395d6209)