### PR TITLE
Strip redundant Notion block metadata

### DIFF
--- a/lib/notion/getPostBlocks.js
+++ b/lib/notion/getPostBlocks.js
@@ -148,6 +148,25 @@ function convertNotionBlocksToPost(id, blockMap, slice) {
       const newUrl = `https://notion.so/signed/${encodeURIComponent(oldUrl)}?table=block&id=${b?.value?.id}`
       b.value.properties.source[0][0] = newUrl
     }
+
+    // 清理冗余元数据减少页面体积
+    if (b) {
+      delete b.role
+      if (b.value) {
+        delete b.value.space_id
+        delete b.value.shard_id
+        delete b.value.version
+        delete b.value.created_by_table
+        delete b.value.created_by_id
+        delete b.value.last_edited_by_table
+        delete b.value.last_edited_by_id
+        delete b.value.permissions
+        if (b.value.format) {
+          delete b.value.format.copied_from_pointer
+          delete b.value.format.block_locked_by
+        }
+      }
+    }
   }
 
   // 去掉不用的字段


### PR DESCRIPTION
## Summary
- remove unused Notion block metadata during conversion to reduce payload size and page data bloat

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cd7cce554832eaaf10efc84450b95)