### PR TITLE
Restore Busuanzi analytics visibility

### DIFF
--- a/components/Busuanzi.js
+++ b/components/Busuanzi.js
@@ -9,12 +9,23 @@ let path = ''
 export default function Busuanzi () {
   const { theme } = useGlobal()
   const router = useRouter()
-  router.events.on('routeChangeComplete', (url, option) => {
-    if (url !== path) {
-      path = url
-      busuanzi.fetch()
+
+  useEffect(() => {
+    const handleRouteChange = url => {
+      if (url !== path) {
+        path = url
+        busuanzi.fetch()
+      }
     }
-  })
+
+    router.events.on('routeChangeComplete', handleRouteChange)
+    // 初始化时主动刷新，避免首屏不更新
+    busuanzi.fetch()
+
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+    }
+  }, [router])
 
   // 更换主题时更新
   useEffect(() => {

--- a/conf/analytics.config.js
+++ b/conf/analytics.config.js
@@ -4,7 +4,7 @@
 module.exports = {
   ANALYTICS_VERCEL: process.env.NEXT_PUBLIC_ANALYTICS_VERCEL || false, // vercel自带的统计 https://vercel.com/docs/concepts/analytics/quickstart https://github.com/tangly1024/NotionNext/issues/897
   ANALYTICS_BUSUANZI_ENABLE:
-    process.env.NEXT_PUBLIC_ANALYTICS_BUSUANZI_ENABLE || true, // 展示网站阅读量、访问数 see http://busuanzi.ibruce.info/
+    process.env.NEXT_PUBLIC_ANALYTICS_BUSUANZI_ENABLE !== 'false', // 展示网站阅读量、访问数 see http://busuanzi.ibruce.info/
   ANALYTICS_BAIDU_ID: process.env.NEXT_PUBLIC_ANALYTICS_BAIDU_ID || '', // e.g 只需要填写百度统计的id，[baidu_id] -> https://hm.baidu.com/hm.js?[baidu_id]
   ANALYTICS_CNZZ_ID: process.env.NEXT_PUBLIC_ANALYTICS_CNZZ_ID || '', // 只需要填写站长统计的id, [cnzz_id] -> https://s9.cnzz.com/z_stat.php?id=[cnzz_id]&web_id=[cnzz_id]
   ANALYTICS_GOOGLE_ID: process.env.NEXT_PUBLIC_ANALYTICS_GOOGLE_ID || 'G-3KGYGDT7H7', // 谷歌Analytics的id e.g: G-XXXXXXXXXX

--- a/conf/analytics.config.js
+++ b/conf/analytics.config.js
@@ -4,7 +4,8 @@
 module.exports = {
   ANALYTICS_VERCEL: process.env.NEXT_PUBLIC_ANALYTICS_VERCEL || false, // vercel自带的统计 https://vercel.com/docs/concepts/analytics/quickstart https://github.com/tangly1024/NotionNext/issues/897
   ANALYTICS_BUSUANZI_ENABLE:
-    process.env.NEXT_PUBLIC_ANALYTICS_BUSUANZI_ENABLE !== 'false', // 展示网站阅读量、访问数 see http://busuanzi.ibruce.info/
+    process.env.NEXT_PUBLIC_ANALYTICS_BUSUANZI_ENABLE !== 'false' && // 默认为开启，只有显式传入 'false' 或 '0' 才关闭
+    process.env.NEXT_PUBLIC_ANALYTICS_BUSUANZI_ENABLE !== '0', // 展示网站阅读量、访问数 see http://busuanzi.ibruce.info/
   ANALYTICS_BAIDU_ID: process.env.NEXT_PUBLIC_ANALYTICS_BAIDU_ID || '', // e.g 只需要填写百度统计的id，[baidu_id] -> https://hm.baidu.com/hm.js?[baidu_id]
   ANALYTICS_CNZZ_ID: process.env.NEXT_PUBLIC_ANALYTICS_CNZZ_ID || '', // 只需要填写站长统计的id, [cnzz_id] -> https://s9.cnzz.com/z_stat.php?id=[cnzz_id]&web_id=[cnzz_id]
   ANALYTICS_GOOGLE_ID: process.env.NEXT_PUBLIC_ANALYTICS_GOOGLE_ID || 'G-3KGYGDT7H7', // 谷歌Analytics的id e.g: G-XXXXXXXXXX


### PR DESCRIPTION
## Summary
- restore Busuanzi analytics to be enabled by default unless explicitly disabled with NEXT_PUBLIC_ANALYTICS_BUSUANZI_ENABLE=false
- retain ability to opt out while keeping safer route-change refresh handling from prior update

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694cda8d0fb8832ebd3dcdd48c547fdc)