### PR TITLE
Ensure sitemap URLs are XML-safe

### DIFF
--- a/lib/sitemap.xml.js
+++ b/lib/sitemap.xml.js
@@ -1,6 +1,20 @@
 import BLOG from '@/blog.config'
 import fs from 'fs'
 import { siteConfig } from './config'
+
+/**
+ * 将 URL 编码并转义为可在 XML 中安全使用的字符串
+ * @param {string} url
+ * @returns {string}
+ */
+function formatSitemapUrl(url) {
+  if (!url) return ''
+  const encodedUrl = encodeURI(url)
+  return encodedUrl
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
 /**
  * 生成站点地图
  * @param {*} param0
@@ -13,24 +27,24 @@ export function generateSitemapXml({ allPages, NOTION_CONFIG }) {
   }
   const urls = [
     {
-      loc: `${link}`,
+      loc: formatSitemapUrl(`${link}`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily',
       priority: 1.0
     },
     {
-      loc: `${link}/archive`,
+      loc: formatSitemapUrl(`${link}/archive`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily',
       priority: 1.0
     },
     {
-      loc: `${link}/category`,
+      loc: formatSitemapUrl(`${link}/category`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     },
     {
-      loc: `${link}/tag`,
+      loc: formatSitemapUrl(`${link}/tag`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     }
@@ -41,7 +55,7 @@ export function generateSitemapXml({ allPages, NOTION_CONFIG }) {
       ? post?.slug?.slice(1)
       : post.slug
     urls.push({
-      loc: `${link}/${slugWithoutLeadingSlash}`,
+      loc: formatSitemapUrl(`${link}/${slugWithoutLeadingSlash}`),
       lastmod: new Date(post?.publishDay).toISOString().split('T')[0],
       changefreq: 'daily'
     })

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -4,6 +4,20 @@ import { getGlobalData } from '@/lib/db/getSiteData'
 import { extractLangId, extractLangPrefix } from '@/lib/utils/pageId'
 import { getServerSideSitemap } from 'next-sitemap'
 
+/**
+ * 将 URL 编码并转义为可在 XML 中安全使用的字符串
+ * @param {string} url
+ * @returns {string}
+ */
+function formatSitemapUrl(url) {
+  if (!url) return ''
+  const encodedUrl = encodeURI(url)
+  return encodedUrl
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
 export const getServerSideProps = async (ctx) => {
   let fields = [] // 用于存储所有 URL 数据
   const siteIds = BLOG.NOTION_PAGE_ID.split(',') // 处理多个站点ID
@@ -60,37 +74,37 @@ function generateLocalesSitemap(link, allPages, locale) {
   // 默认页面 URL 配置
   const defaultFields = [
     {
-      loc: `${link}${locale}`,
+      loc: formatSitemapUrl(`${link}${locale}`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/archive`,
+      loc: formatSitemapUrl(`${link}${locale}/archive`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/category`,
+      loc: formatSitemapUrl(`${link}${locale}/category`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/rss/feed.xml`,
+      loc: formatSitemapUrl(`${link}${locale}/rss/feed.xml`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/search`,
+      loc: formatSitemapUrl(`${link}${locale}/search`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/tag`,
+      loc: formatSitemapUrl(`${link}${locale}/tag`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
@@ -107,7 +121,7 @@ function generateLocalesSitemap(link, allPages, locale) {
           : post.slug
         const lastmod = post?.publishDay ? new Date(post?.publishDay).toISOString().split('T')[0] : dateNow
         return {
-          loc: `${link}${locale}/${slugWithoutLeadingSlash}`,
+          loc: formatSitemapUrl(`${link}${locale}/${slugWithoutLeadingSlash}`),
           lastmod,
           changefreq: 'daily',
           priority: '0.7'


### PR DESCRIPTION
## Summary
- encode sitemap URLs before inserting into the XML sitemap for both static and dynamic generation paths
- prevent malformed sitemap output when page links include special characters

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce973046c832e840d74b5fdfeaa32)