### PR TITLE
Harden sitemap XML output and headers

### DIFF
--- a/lib/sitemap.xml.js
+++ b/lib/sitemap.xml.js
@@ -1,6 +1,33 @@
 import BLOG from '@/blog.config'
 import fs from 'fs'
 import { siteConfig } from './config'
+
+/**
+ * 移除 XML 不允许的控制字符
+ * @param {string} value
+ * @returns {string}
+ */
+function stripInvalidXmlChars(value) {
+  if (!value) return ''
+  return value.replace(/[\u0000-\u0008\u000B-\u000C\u000E-\u001F\u007F]/g, '')
+}
+
+/**
+ * 将 URL 编码并转义为可在 XML 中安全使用的字符串
+ * @param {string} url
+ * @returns {string}
+ */
+function formatSitemapUrl(url) {
+  const sanitized = stripInvalidXmlChars(url)
+  if (!sanitized) return ''
+  const encodedUrl = encodeURI(sanitized)
+  return encodedUrl
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
 /**
  * 生成站点地图
  * @param {*} param0
@@ -13,24 +40,24 @@ export function generateSitemapXml({ allPages, NOTION_CONFIG }) {
   }
   const urls = [
     {
-      loc: `${link}`,
+      loc: formatSitemapUrl(`${link}`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily',
       priority: 1.0
     },
     {
-      loc: `${link}/archive`,
+      loc: formatSitemapUrl(`${link}/archive`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily',
       priority: 1.0
     },
     {
-      loc: `${link}/category`,
+      loc: formatSitemapUrl(`${link}/category`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     },
     {
-      loc: `${link}/tag`,
+      loc: formatSitemapUrl(`${link}/tag`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     }
@@ -41,8 +68,8 @@ export function generateSitemapXml({ allPages, NOTION_CONFIG }) {
       ? post?.slug?.slice(1)
       : post.slug
     urls.push({
-      loc: `${link}/${slugWithoutLeadingSlash}`,
-      lastmod: new Date(post?.publishDay).toISOString().split('T')[0],
+      loc: formatSitemapUrl(`${link}/${slugWithoutLeadingSlash}`),
+      lastmod: new Date(post?.publishDay || Date.now()).toISOString().split('T')[0],
       changefreq: 'daily'
     })
   })
@@ -63,6 +90,7 @@ export function generateSitemapXml({ allPages, NOTION_CONFIG }) {
 function createSitemapXml(urls) {
   let urlsXml = ''
   urls.forEach(u => {
+    if (!u?.loc) return
     urlsXml += `<url>
     <loc>${u.loc}</loc>
     <lastmod>${u.lastmod}</lastmod>
@@ -71,13 +99,12 @@ function createSitemapXml(urls) {
     `
   })
 
-  return `
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-    xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
-    xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
-    xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-    ${urlsXml}
-    </urlset>
-    `
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+xmlns:xhtml="http://www.w3.org/1999/xhtml"
+xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
+xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+${urlsXml}
+</urlset>`
 }


### PR DESCRIPTION
## Summary
- strip invalid XML control characters and prepend the XML declaration when generating static sitemaps
- skip malformed entries, fully escape URLs, and add proper XML response headers for dynamic sitemap responses

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce973046c832e840d74b5fdfeaa32)