### PR TITLE
Prefer current host for sitemap links

### DIFF
--- a/lib/sitemap.xml.js
+++ b/lib/sitemap.xml.js
@@ -1,6 +1,33 @@
 import BLOG from '@/blog.config'
 import fs from 'fs'
 import { siteConfig } from './config'
+
+/**
+ * 移除 XML 不允许的控制字符
+ * @param {string} value
+ * @returns {string}
+ */
+function stripInvalidXmlChars(value) {
+  if (!value) return ''
+  return value.replace(/[\u0000-\u0008\u000B-\u000C\u000E-\u001F\u007F]/g, '')
+}
+
+/**
+ * 将 URL 编码并转义为可在 XML 中安全使用的字符串
+ * @param {string} url
+ * @returns {string}
+ */
+function formatSitemapUrl(url) {
+  const sanitized = stripInvalidXmlChars(url)
+  if (!sanitized) return ''
+  const encodedUrl = encodeURI(sanitized)
+  return encodedUrl
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
 /**
  * 生成站点地图
  * @param {*} param0
@@ -13,24 +40,24 @@ export function generateSitemapXml({ allPages, NOTION_CONFIG }) {
   }
   const urls = [
     {
-      loc: `${link}`,
+      loc: formatSitemapUrl(`${link}`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily',
       priority: 1.0
     },
     {
-      loc: `${link}/archive`,
+      loc: formatSitemapUrl(`${link}/archive`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily',
       priority: 1.0
     },
     {
-      loc: `${link}/category`,
+      loc: formatSitemapUrl(`${link}/category`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     },
     {
-      loc: `${link}/tag`,
+      loc: formatSitemapUrl(`${link}/tag`),
       lastmod: new Date().toISOString().split('T')[0],
       changefreq: 'daily'
     }
@@ -41,8 +68,8 @@ export function generateSitemapXml({ allPages, NOTION_CONFIG }) {
       ? post?.slug?.slice(1)
       : post.slug
     urls.push({
-      loc: `${link}/${slugWithoutLeadingSlash}`,
-      lastmod: new Date(post?.publishDay).toISOString().split('T')[0],
+      loc: formatSitemapUrl(`${link}/${slugWithoutLeadingSlash}`),
+      lastmod: new Date(post?.publishDay || Date.now()).toISOString().split('T')[0],
       changefreq: 'daily'
     })
   })
@@ -63,6 +90,7 @@ export function generateSitemapXml({ allPages, NOTION_CONFIG }) {
 function createSitemapXml(urls) {
   let urlsXml = ''
   urls.forEach(u => {
+    if (!u?.loc) return
     urlsXml += `<url>
     <loc>${u.loc}</loc>
     <lastmod>${u.lastmod}</lastmod>
@@ -71,13 +99,12 @@ function createSitemapXml(urls) {
     `
   })
 
-  return `
-    <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-    xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
-    xmlns:xhtml="http://www.w3.org/1999/xhtml"
-    xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
-    xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-    ${urlsXml}
-    </urlset>
-    `
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+xmlns:news="http://www.google.com/schemas/sitemap-news/0.9"
+xmlns:xhtml="http://www.w3.org/1999/xhtml"
+xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0"
+xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+${urlsXml}
+</urlset>`
 }

--- a/pages/sitemap.xml.js
+++ b/pages/sitemap.xml.js
@@ -4,6 +4,60 @@ import { getGlobalData } from '@/lib/db/getSiteData'
 import { extractLangId, extractLangPrefix } from '@/lib/utils/pageId'
 import { getServerSideSitemap } from 'next-sitemap'
 
+/**
+ * 规范化域名链接，移除尾部斜杠
+ */
+function normalizeLink(link) {
+  if (!link) return ''
+  return link.endsWith('/') ? link.slice(0, -1) : link
+}
+
+/**
+ * 将 URL 编码并转义为可在 XML 中安全使用的字符串
+ * @param {string} url
+ * @returns {string}
+ */
+function formatSitemapUrl(url) {
+  if (!url) return ''
+  // 去除 XML 不允许的控制字符
+  const sanitized = url.replace(/[\u0000-\u0008\u000B-\u000C\u000E-\u001F\u007F]/g, '')
+  if (!sanitized) return ''
+  const encodedUrl = encodeURI(sanitized)
+  return encodedUrl
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+/**
+ * 如果配置的域名与当前访问域名不一致，优先使用当前请求域名，避免生成不被允许的 URL
+ */
+function resolveSiteLink(configLink, req) {
+  const normalizedConfig = normalizeLink(configLink)
+  const host = req?.headers?.host
+  const protocol = req?.headers?.['x-forwarded-proto'] || 'https'
+  const runtimeLink = host ? `${protocol}://${host}` : ''
+  const normalizedRuntime = normalizeLink(runtimeLink)
+
+  if (!normalizedConfig) return normalizedRuntime
+  if (!normalizedRuntime) return normalizedConfig
+
+  try {
+    const configUrl = new URL(normalizedConfig)
+    const runtimeUrl = new URL(normalizedRuntime)
+    if (configUrl.host !== runtimeUrl.host) {
+      return normalizedRuntime
+    }
+  } catch {
+    // 如果 URL 无法解析，兜底返回配置的
+    return normalizedConfig || normalizedRuntime
+  }
+
+  return normalizedConfig
+}
+
 export const getServerSideProps = async (ctx) => {
   let fields = [] // 用于存储所有 URL 数据
   const siteIds = BLOG.NOTION_PAGE_ID.split(',') // 处理多个站点ID
@@ -23,11 +77,12 @@ export const getServerSideProps = async (ctx) => {
     }
 
     // 获取站点的 URL 配置
-    const link = siteConfig(
+    const configLink = siteConfig(
       'LINK',
       siteData?.siteInfo?.link,
       siteData.NOTION_CONFIG
     )
+    const link = resolveSiteLink(configLink, ctx.req)
 
     // 生成本地化的站点地图
     const localeFields = generateLocalesSitemap(link, siteData.allPages, locale)
@@ -37,7 +92,8 @@ export const getServerSideProps = async (ctx) => {
   // 确保 URL 唯一性
   fields = getUniqueFields(fields)
 
-  // 设置缓存控制（1小时有效，59秒过期）
+  // 设置响应头，确保以 XML 返回且可缓存（1小时有效，59秒过期）
+  ctx.res.setHeader('Content-Type', 'text/xml; charset=utf-8')
   ctx.res.setHeader('Cache-Control', 'public, max-age=3600, stale-while-revalidate=59')
 
   // 返回站点地图数据
@@ -60,37 +116,37 @@ function generateLocalesSitemap(link, allPages, locale) {
   // 默认页面 URL 配置
   const defaultFields = [
     {
-      loc: `${link}${locale}`,
+      loc: formatSitemapUrl(`${link}${locale}`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/archive`,
+      loc: formatSitemapUrl(`${link}${locale}/archive`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/category`,
+      loc: formatSitemapUrl(`${link}${locale}/category`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/rss/feed.xml`,
+      loc: formatSitemapUrl(`${link}${locale}/rss/feed.xml`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/search`,
+      loc: formatSitemapUrl(`${link}${locale}/search`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
     },
     {
-      loc: `${link}${locale}/tag`,
+      loc: formatSitemapUrl(`${link}${locale}/tag`),
       lastmod: dateNow,
       changefreq: 'daily',
       priority: '0.7'
@@ -107,7 +163,7 @@ function generateLocalesSitemap(link, allPages, locale) {
           : post.slug
         const lastmod = post?.publishDay ? new Date(post?.publishDay).toISOString().split('T')[0] : dateNow
         return {
-          loc: `${link}${locale}/${slugWithoutLeadingSlash}`,
+          loc: formatSitemapUrl(`${link}${locale}/${slugWithoutLeadingSlash}`),
           lastmod,
           changefreq: 'daily',
           priority: '0.7'


### PR DESCRIPTION
## Summary
- prefer the current request host over stale config when building sitemap URLs to avoid disallowed domains
- keep URL escaping and sitemap XML headers intact for valid output

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ce973046c832e840d74b5fdfeaa32)