### PR TITLE
Re-sign Notion file links on cache hits

### DIFF
--- a/lib/notion/getPostBlocks.js
+++ b/lib/notion/getPostBlocks.js
@@ -16,27 +16,20 @@ import notionAPI from '@/lib/notion/getNotionAPI'
  */
 export async function getPage(id, from = null, slice) {
   const cacheKey = `page_content_${id}`
-  return await getOrSetDataWithCache(
-    cacheKey,
-    async (id, slice) => {
-      let pageBlock = await getDataFromCache(cacheKey)
-      if (pageBlock) {
-        // console.debug('[API<<--缓存]', `from:${from}`, cacheKey)
-        return convertNotionBlocksToPost(id, pageBlock, slice)
-      }
+  // 直接从缓存读取原始 block 数据，再按需重新签名文件链接，避免缓存中过期的签名导致附件无法下载
+  const pageBlockFromCache = await getDataFromCache(cacheKey)
+  if (pageBlockFromCache) {
+    return convertNotionBlocksToPost(id, pageBlockFromCache, slice)
+  }
 
-      // 抓取最新数据
-      pageBlock = await getPageWithRetry(id, from)
+  // 缓存不存在时抓取最新数据
+  const pageBlock = await getPageWithRetry(id, from)
 
-      if (pageBlock) {
-        await setDataToCache(cacheKey, pageBlock)
-        return convertNotionBlocksToPost(id, pageBlock, slice)
-      }
-      return pageBlock
-    },
-    id,
-    slice
-  )
+  if (pageBlock) {
+    await setDataToCache(cacheKey, pageBlock)
+    return convertNotionBlocksToPost(id, pageBlock, slice)
+  }
+  return pageBlock
 }
 
 /**


### PR DESCRIPTION
## Summary
- avoid using cached signed URLs directly for Notion file blocks
- re-sign file, PDF, video, and audio sources when loading from cache to prevent expired downloads

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e7338260832e80513a8dcc6d58c1)