### PR TITLE
Normalize cached Notion signed file URLs before re-signing

### DIFF
--- a/lib/notion/getPostBlocks.js
+++ b/lib/notion/getPostBlocks.js
@@ -16,27 +16,20 @@ import notionAPI from '@/lib/notion/getNotionAPI'
  */
 export async function getPage(id, from = null, slice) {
   const cacheKey = `page_content_${id}`
-  return await getOrSetDataWithCache(
-    cacheKey,
-    async (id, slice) => {
-      let pageBlock = await getDataFromCache(cacheKey)
-      if (pageBlock) {
-        // console.debug('[API<<--缓存]', `from:${from}`, cacheKey)
-        return convertNotionBlocksToPost(id, pageBlock, slice)
-      }
+  // 直接从缓存读取原始 block 数据，再按需重新签名文件链接，避免缓存中过期的签名导致附件无法下载
+  const pageBlockFromCache = await getDataFromCache(cacheKey)
+  if (pageBlockFromCache) {
+    return convertNotionBlocksToPost(id, pageBlockFromCache, slice)
+  }
 
-      // 抓取最新数据
-      pageBlock = await getPageWithRetry(id, from)
+  // 缓存不存在时抓取最新数据
+  const pageBlock = await getPageWithRetry(id, from)
 
-      if (pageBlock) {
-        await setDataToCache(cacheKey, pageBlock)
-        return convertNotionBlocksToPost(id, pageBlock, slice)
-      }
-      return pageBlock
-    },
-    id,
-    slice
-  )
+  if (pageBlock) {
+    await setDataToCache(cacheKey, pageBlock)
+    return convertNotionBlocksToPost(id, pageBlock, slice)
+  }
+  return pageBlock
 }
 
 /**
@@ -145,7 +138,8 @@ function convertNotionBlocksToPost(id, blockMap, slice) {
         b?.value?.properties?.source?.[0][0].indexOf('amazonaws.com') > 0)
     ) {
       const oldUrl = b?.value?.properties?.source?.[0][0]
-      const newUrl = `https://notion.so/signed/${encodeURIComponent(oldUrl)}?table=block&id=${b?.value?.id}`
+      const rawUrl = normalizeSignedUrl(oldUrl)
+      const newUrl = `https://notion.so/signed/${encodeURIComponent(rawUrl)}?table=block&id=${b?.value?.id}`
       b.value.properties.source[0][0] = newUrl
     }
 
@@ -174,6 +168,27 @@ function convertNotionBlocksToPost(id, blockMap, slice) {
     return clonePageBlock
   }
   return clonePageBlock
+}
+
+/**
+ * 当缓存中的文件链接已经是 notion 的 signed 链接时，先解码回原始文件地址
+ * 再重新生成新的 signed URL，防止因再次签名已过期链接导致下载失败
+ * @param {*} url
+ * @returns
+ */
+function normalizeSignedUrl(url) {
+  if (!url) return url
+  try {
+    const SIGNED_PREFIX = 'https://notion.so/signed/'
+    if (url.startsWith(SIGNED_PREFIX)) {
+      const unsigned = decodeURIComponent(url.substring(SIGNED_PREFIX.length).split('?')[0])
+      return unsigned || url
+    }
+    return url
+  } catch (error) {
+    console.warn('[normalizeSignedUrl] failed, fallback to original url', error)
+    return url
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- decode cached notion.signed URLs back to the original file URL before re-signing
- regenerate fresh signed links for file, PDF, video, and audio blocks even when cache hits to avoid expired downloads

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951e7338260832e80513a8dcc6d58c1)