### PR TITLE
fix: add null checks to prevent indexOf/replaceAll errors during prer…

### DIFF
--- a/lib/db/notion/getPageTableOfContents.js
+++ b/lib/db/notion/getPageTableOfContents.js
@@ -72,7 +72,7 @@ function getBlockHeader(contents, recordMap, toc) {
     if (block.content?.length > 0) {
       getBlockHeader(block.content, recordMap, toc)
     } else {
-      if (type.indexOf('header') >= 0) {
+      if (type && type.indexOf('header') >= 0) {
         const existed = toc.find(e => e.id === blockId)
         if (!existed) {
           toc.push({

--- a/lib/utils/post.js
+++ b/lib/utils/post.js
@@ -23,7 +23,7 @@ export function getRecommendPost(post, allPosts, count = 6) {
   const currentTags = post?.tags || []
   for (let i = 0; i < allPosts.length; i++) {
     const p = allPosts[i]
-    if (p.id === post.id || p.type.indexOf('Post') < 0) {
+    if (p.id === post.id || !p.type || p.type.indexOf('Post') < 0) {
       continue
     }
 
@@ -52,13 +52,14 @@ export function getRecommendPost(post, allPosts, count = 6) {
  */
 export function checkSlugHasNoSlash(row) {
   let slug = row.slug
+  if (!slug) return false
   if (slug.startsWith('/')) {
     slug = slug.substring(1)
   }
   return (
     (slug.match(/\//g) || []).length === 0 &&
     !isHttpLink(slug) &&
-    row.type.indexOf('Menu') < 0
+    (!row.type || row.type.indexOf('Menu') < 0)
   )
 }
 
@@ -69,13 +70,14 @@ export function checkSlugHasNoSlash(row) {
  */
 export function checkSlugHasOneSlash(row) {
   let slug = row.slug
+  if (!slug) return false
   if (slug.startsWith('/')) {
     slug = slug.substring(1)
   }
   return (
     (slug.match(/\//g) || []).length === 1 &&
     !isHttpLink(slug) &&
-    row.type.indexOf('Menu') < 0
+    (!row.type || row.type.indexOf('Menu') < 0)
   )
 }
 
@@ -86,12 +88,13 @@ export function checkSlugHasOneSlash(row) {
  */
 export function checkSlugHasMorThanTwoSlash(row) {
   let slug = row.slug
+  if (!slug) return false
   if (slug.startsWith('/')) {
     slug = slug.substring(1)
   }
   return (
     (slug.match(/\//g) || []).length >= 2 &&
-    row.type.indexOf('Menu') < 0 &&
+    (!row.type || row.type.indexOf('Menu') < 0) &&
     !isHttpLink(slug)
   )
 }

--- a/themes/nav/components/LogoBar.js
+++ b/themes/nav/components/LogoBar.js
@@ -14,7 +14,7 @@ export default function LogoBar(props) {
         <div id='top-wrapper' className='w-full flex items-center'>
                 <SmartLink href='/' className='md:w-48 grid justify-items-center text-md md:text-xl dark:text-gray-200'>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
-                    <img src={siteInfo?.icon?.replaceAll('width=400', 'width=280')}
+                    <img src={siteInfo?.icon ? siteInfo.icon.replaceAll('width=400', 'width=280') : ''}
                         height='44px' alt={siteConfig('AUTHOR') + ' - ' + siteConfig('NEXT_PUBLIC_BIO')} className='md:block transition-all hover:scale-110 duration-150' placeholderSrc='' />
                     {siteConfig('NAV_SHOW_TITLE_TEXT', null, CONFIG) && siteConfig('TITLE')}
                 </SmartLink>


### PR DESCRIPTION
…endering

Guard against undefined `type` and `slug` properties on post/block objects that cause build failures when prerendering pages like /zh-CN/learning/example-1.

- getPageTableOfContents: check block.type before calling indexOf('header')
- post.js: check row.type before calling indexOf('Menu') in slug checkers
- post.js: check row.slug before calling startsWith('/') in slug checkers
- post.js: check p.type before calling indexOf('Post') in getRecommendPost
- LogoBar: use explicit truthy check on siteInfo.icon before replaceAll

https://claude.ai/code/session_01R6jGceUnCPSB4PSTBkrFYz

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
