### PR TITLE
fix: prevent prerender crash on /zh-CN/learning/example-1

### DIFF
--- a/lib/db/notion/getPageContentText.js
+++ b/lib/db/notion/getPageContentText.js
@@ -102,12 +102,15 @@ export function getPageContentText(post, pageBlockMap) {
 
   function getTransclusionReference(block) {
     const result = []
-    const blockPointer = block.format.transclusion_reference_pointer
+    const blockPointer = block?.format?.transclusion_reference_pointer
+    if (!blockPointer) return ''
     const blockPointerId = blockPointer.id
-    if (blockPointer && pageBlockMap.block[blockPointerId].value) {
+    if (blockPointerId && pageBlockMap.block[blockPointerId]?.value) {
       const blockContentList = pageBlockMap.block[blockPointerId].value.content
-      for (const blockContent of blockContentList) {
-        result.push(getBlockContentText(blockContent))
+      if (Array.isArray(blockContentList)) {
+        for (const blockContent of blockContentList) {
+          result.push(getBlockContentText(blockContent))
+        }
       }
     }
     return result.join(' ')
@@ -152,6 +155,7 @@ export function getPageContentText(post, pageBlockMap) {
 
   function getTableText(tableRowIds) {
     const result = []
+    if (!Array.isArray(tableRowIds)) return ''
     for (const blockRowId of tableRowIds) {
       if (pageBlockMap.block[blockRowId]) {
         const blockRow = pageBlockMap.block[blockRowId].value

--- a/lib/db/notion/getPageTableOfContents.js
+++ b/lib/db/notion/getPageTableOfContents.js
@@ -89,7 +89,9 @@ function getBlockHeader(contents, recordMap, toc) {
           toc
         )
       } else if (type === 'transclusion_container') {
-          getBlockHeader(block.content, recordMap, toc)
+          if (Array.isArray(block.content)) {
+            getBlockHeader(block.content, recordMap, toc)
+          }
       }
     }
   }

--- a/lib/db/notion/getPostBlocks.js
+++ b/lib/db/notion/getPostBlocks.js
@@ -90,8 +90,20 @@ export function formatNotionBlock(block) {
     const blockId = blocksToProcess[i]
     const b = clonedBlock[blockId]
 
-    // === 【新增】强制修复非法 URL ===
+    // === 强制修复非法 URL ===
     sanitizeBlockUrls(b?.value)
+
+    // Ensure block has a valid id (react-notion-x calls uuidToId(block.id))
+    if (b?.value && !b.value.id) {
+      b.value.id = blockId
+    }
+
+    // Filter content array to only reference blocks that exist in the blockMap
+    if (Array.isArray(b?.value?.content)) {
+      b.value.content = b.value.content.filter(
+        childId => childId && clonedBlock[childId]
+      )
+    }
 
     if (b?.value?.type === 'sync_block' && b?.value?.children) {
       const childBlocks = b.value.children


### PR DESCRIPTION
Guard against non-iterable block.content in getPageContentText and getPageTableOfContents by adding Array.isArray checks before for-of loops. Sanitize blockMap in formatNotionBlock to ensure every block has a valid id (preventing uuidToId(undefined) in react-notion-x) and filter content arrays to only reference blocks that exist in the map.

https://claude.ai/code/session_01UYN3qwF5P5ZVnwk4eTpELv

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
