### PR TITLE
feat: add Notion-backed /links page with robust URL and logo fallbacks

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -1,0 +1,217 @@
+const NOTION_API_BASE = 'https://api.notion.com/v1'
+const NOTION_VERSION = '2022-06-28'
+const REQUEST_TIMEOUT = 10000
+const RETRY_COUNT = 2
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+function getDatabaseId() {
+  return (
+    process.env.NOTION_LINKS_DB_ID ||
+    process.env.NOTION_DATABASE_ID ||
+    process.env.LINKS_DB_ID ||
+    process.env.DB_ID ||
+    ''
+  )
+}
+
+function pick(properties = {}, keys = []) {
+  for (const key of keys) {
+    if (properties[key]) return properties[key]
+  }
+  return null
+}
+
+function getTextValue(prop) {
+  if (!prop) return ''
+  if (prop.type === 'title') {
+    return (prop.title || []).map(it => it.plain_text || '').join('').trim()
+  }
+  if (prop.type === 'rich_text') {
+    return (prop.rich_text || []).map(it => it.plain_text || '').join('').trim()
+  }
+  if (prop.type === 'url') {
+    return (prop.url || '').trim()
+  }
+  if (prop.type === 'select') {
+    return prop.select?.name?.trim() || ''
+  }
+  if (prop.type === 'multi_select') {
+    return (prop.multi_select || [])
+      .map(it => it.name || '')
+      .filter(Boolean)
+      .join(',')
+      .trim()
+  }
+  if (prop.type === 'email' || prop.type === 'phone_number') {
+    return (prop[prop.type] || '').trim()
+  }
+  return ''
+}
+
+function getNumberValue(prop) {
+  if (!prop) return 0
+  if (prop.type === 'number') return Number(prop.number || 0)
+  const n = Number(getTextValue(prop))
+  return Number.isFinite(n) ? n : 0
+}
+
+function getCategoryValues(prop) {
+  if (!prop) return []
+  if (prop.type === 'multi_select') {
+    return (prop.multi_select || []).map(it => it.name).filter(Boolean)
+  }
+  if (prop.type === 'select') {
+    return prop.select?.name ? [prop.select.name] : []
+  }
+  const text = getTextValue(prop)
+  if (!text) return []
+  return text
+    .split(/[，,|/]/)
+    .map(s => s.trim())
+    .filter(Boolean)
+}
+
+function withHttps(url = '') {
+  const value = (url || '').trim()
+  if (!value) return ''
+  if (/^https?:\/\//i.test(value)) return value
+  return `https://${value}`
+}
+
+function getFavicon(url = '') {
+  try {
+    const normalized = withHttps(url)
+    if (!normalized) return '/favicon.ico'
+    const { hostname } = new URL(normalized)
+    if (!hostname) return '/favicon.ico'
+    return `https://icons.duckduckgo.com/ip3/${hostname}.ico`
+  } catch (error) {
+    return '/favicon.ico'
+  }
+}
+
+function resolveAvatar(avatarProp, url) {
+  if (avatarProp?.type === 'url' && avatarProp.url) {
+    return avatarProp.url
+  }
+  if (avatarProp?.type === 'files') {
+    const file = avatarProp.files?.[0]
+    if (file?.type === 'external' && file.external?.url) return file.external.url
+    if (file?.type === 'file' && file.file?.url) return file.file.url
+  }
+  return getFavicon(url)
+}
+
+async function notion(path, options = {}, retry = 0) {
+  const token = process.env.NOTION_TOKEN
+  if (!token) throw new Error('Missing NOTION_TOKEN')
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT)
+
+  try {
+    const response = await fetch(`${NOTION_API_BASE}${path}`, {
+      ...options,
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+        ...(options.headers || {})
+      }
+    })
+
+    if ((response.status === 429 || response.status >= 500) && retry < RETRY_COUNT) {
+      await sleep(400 * (retry + 1))
+      return notion(path, options, retry + 1)
+    }
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Notion API ${response.status}: ${text}`)
+    }
+
+    return response.json()
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function parseItems(results = []) {
+  return results
+    .map(page => {
+      const properties = page?.properties || {}
+      const nameProp = pick(properties, ['Name', '名称', '标题'])
+      const urlProp = pick(properties, ['URL', 'Link', '链接'])
+      const categoryProp = pick(properties, ['Category', '分类'])
+      const avatarProp = pick(properties, ['Avatar', 'Icon', '图标'])
+      const descProp = pick(properties, ['Description', '描述', '简介', 'Desc'])
+      const weightProp = pick(properties, ['Weight', '权重'])
+
+      const Name = getTextValue(nameProp)
+      const URL = withHttps(getTextValue(urlProp))
+      if (!Name || !URL) return null
+
+      const Categories = getCategoryValues(categoryProp)
+      const Description = getTextValue(descProp)
+      const Weight = getNumberValue(weightProp)
+      const Logo = resolveAvatar(avatarProp, URL)
+
+      return {
+        id: page.id,
+        Name,
+        URL,
+        Categories,
+        Description,
+        Weight,
+        Logo,
+        Avatar: Logo
+      }
+    })
+    .filter(Boolean)
+}
+
+export async function getLinksAndCategories() {
+  const dbId = getDatabaseId()
+  if (!dbId) throw new Error('Missing links database id env (NOTION_LINKS_DB_ID/DB_ID)')
+
+  const db = await notion(`/databases/${dbId}`, { method: 'GET' })
+  const categoryProperty = pick(db?.properties || {}, ['Category', '分类'])
+  const categoryOptions = (categoryProperty?.select?.options || categoryProperty?.multi_select?.options || [])
+    .map(it => it.name)
+    .filter(Boolean)
+
+  const results = []
+  let hasMore = true
+  let cursor
+
+  while (hasMore) {
+    const body = {
+      page_size: 100,
+      ...(cursor ? { start_cursor: cursor } : {})
+    }
+    const data = await notion(`/databases/${dbId}/query`, {
+      method: 'POST',
+      body: JSON.stringify(body)
+    })
+
+    results.push(...(data.results || []))
+    hasMore = Boolean(data.has_more)
+    cursor = data.next_cursor
+  }
+
+  const items = parseItems(results)
+  const usedCategories = Array.from(
+    new Set(items.flatMap(it => it.Categories || []).filter(Boolean))
+  )
+
+  const categories = [...categoryOptions]
+  for (const cat of usedCategories) {
+    if (!categories.includes(cat)) categories.push(cat)
+  }
+
+  return { items, categories }
+}
+
+export { getFavicon, resolveAvatar, withHttps }

--- a/pages/links.js
+++ b/pages/links.js
@@ -1,0 +1,128 @@
+import Head from 'next/head'
+import { getFavicon, getLinksAndCategories } from '@/lib/links'
+
+export async function getStaticProps() {
+  try {
+    const { items, categories } = await getLinksAndCategories()
+    return {
+      props: { items, categories },
+      revalidate: 600
+    }
+  } catch (error) {
+    console.error('[links] fetch error:', error)
+    return {
+      props: { items: [], categories: [] },
+      revalidate: 300
+    }
+  }
+}
+
+function sortItems(list = []) {
+  return [...list].sort((a, b) => {
+    const w = (b.Weight || 0) - (a.Weight || 0)
+    if (w !== 0) return w
+    return (a.Name || '').localeCompare(b.Name || '', 'zh-Hans-CN')
+  })
+}
+
+export default function LinksPage({ items = [], categories = [] }) {
+  const visibleCategories = categories.filter(Boolean)
+
+  return (
+    <>
+      <Head>
+        <title>友情链接</title>
+      </Head>
+
+      <main style={{ maxWidth: 1000, margin: '0 auto', padding: '24px 16px' }}>
+        <h1 style={{ fontSize: 28, marginBottom: 20 }}>友情链接</h1>
+
+        {visibleCategories.length === 0 && <p>暂无数据</p>}
+
+        {visibleCategories.map(cat => {
+          const group = sortItems(
+            items.filter(it => (it.Categories || []).includes(cat))
+          )
+          if (group.length === 0) return null
+
+          return (
+            <section key={cat} style={{ marginBottom: 28 }}>
+              <h2 style={{ fontSize: 22, marginBottom: 12 }}>{cat}</h2>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))',
+                  gap: 12
+                }}
+              >
+                {group.map(it => (
+                  <a
+                    key={it.id}
+                    href={it.URL}
+                    target='_blank'
+                    rel='noopener noreferrer nofollow external'
+                    onClick={e => e.stopPropagation()}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      border: '1px solid #e5e7eb',
+                      borderRadius: 10,
+                      padding: 12,
+                      textDecoration: 'none',
+                      color: 'inherit',
+                      background: '#fff'
+                    }}
+                  >
+                    <img
+                      src={it.Logo || it.Avatar}
+                      alt={it.Name}
+                      width={40}
+                      height={40}
+                      loading='lazy'
+                      style={{ borderRadius: 8, marginRight: 12, flexShrink: 0 }}
+                      onError={e => {
+                        if (!e.currentTarget.dataset.fallback) {
+                          e.currentTarget.dataset.fallback = 'favicon'
+                          e.currentTarget.src = getFavicon(it.URL)
+                        } else if (e.currentTarget.dataset.fallback === 'favicon') {
+                          e.currentTarget.dataset.fallback = 'local'
+                          e.currentTarget.src = '/favicon.ico'
+                        }
+                      }}
+                    />
+                    <span style={{ minWidth: 0 }}>
+                      <strong
+                        style={{
+                          display: 'block',
+                          marginBottom: 4,
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis'
+                        }}
+                      >
+                        {it.Name}
+                      </strong>
+                      {it.Description && (
+                        <small
+                          style={{
+                            display: 'block',
+                            color: '#6b7280',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap'
+                          }}
+                        >
+                          {it.Description}
+                        </small>
+                      )}
+                    </span>
+                  </a>
+                ))}
+              </div>
+            </section>
+          )
+        })}
+      </main>
+    </>
+  )
+}


### PR DESCRIPTION
### Motivation

- Provide a simple `/links` page powered by a Notion database so site admins can manage link items from Notion. 
- Make link data robust for static builds by normalizing URLs, guaranteeing a logo (avatar or favicon) and making Notion requests resilient to timeouts and transient errors. 
- Keep scope minimal and safe by only adding the two required files (`lib/links.js` and `pages/links.js`).

### Description

- Add `lib/links.js` which implements `getLinksAndCategories()` and helpers to fetch the database schema and paginated query results, normalize mixed CN/EN property names, and parse properties into usable fields. 
- Implement `withHttps()`, `resolveAvatar()`, and `getFavicon()` so URLs always include a protocol and avatars/logos fall back to DuckDuckGo favicons and finally `/favicon.ico`. 
- Make Notion API requests robust via `notion()` with a 10s `AbortController` timeout and retry on `429`/`5xx` responses (simple backoff, 2 retries). 
- Add `pages/links.js` which uses `getStaticProps()` to call `getLinksAndCategories()`, returns `revalidate: 600` (and `revalidate: 300` with empty arrays on fetch error), groups items by Category (respecting database option order + used categories), sorts items by `Weight` desc then `Name`, uses safe external link attributes and `onClick={e => e.stopPropagation()}`, and implements an `img` `onError` fallback chain (`logo -> duckduckgo favicon -> /favicon.ico`).

### Testing

- Ran linting with `npm run lint -- --file pages/links.js --file lib/links.js`, which passed with only the Next.js advisory warning about using `<Image />` instead of `<img>`. 
- Built/compiled the dev server and pages which completed successfully during `next dev` compilation (pages compiled). 
- Attempted an automated Playwright screenshot of `/links`, but the headless Chromium process crashed (SIGSEGV) in this environment, so the end-to-end render capture failed and is unrelated to the code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69953d4c0cb8832e8ddf3a15f2d8617b)