### PR TITLE
Add friends links page with Notion DB integration

### DIFF
--- a/lib/links.js
+++ b/lib/links.js
@@ -1,0 +1,157 @@
+// /lib/links.js
+// Env: NOTION_TOKEN (required), FRIENDS_DB_ID (optional)
+const NOTION_TOKEN = process.env.NOTION_TOKEN
+const DB_ID = process.env.FRIENDS_DB_ID || '2755906f3c428088928dfc62610854dc'
+const NOTION_VERSION = '2022-06-28'
+
+// helpers
+const pick = (props, names) => { for (const n of names) if (props && props[n]) return props[n] }
+const t    = p => ((p && p.title) || []).map(x => (x && x.plain_text) || '').join('')
+const rich = p => ((p && p.rich_text) || []).map(x => (x && x.plain_text) || '').join('')
+const url  = p => (p && p.url) || ''
+const sel  = p => (p && p.select && p.select.name) || ''
+const num  = p => (typeof (p && p.number) === 'number' ? p.number : 0)
+
+// ensure https://
+const withHttps = u => {
+  if (!u) return ''
+  const s = String(u).trim()
+  return /^https?:\/\//i.test(s) ? s : 'https://' + s.replace(/^\/+/, '')
+}
+
+// favicon fallback (DuckDuckGo)
+const getFavicon = site => {
+  try {
+    const { hostname } = new URL(withHttps(site))
+    return 'https://icons.duckduckgo.com/ip3/' + hostname + '.ico'
+  } catch {
+    return '/favicon.ico'
+  }
+}
+
+// avatar priority: Avatar(files/external) -> Avatar(url) -> domain favicon
+function resolveAvatar(avatarProp, siteUrl) {
+  const f = avatarProp && avatarProp.files && avatarProp.files[0]
+  if (f) {
+    if (f.type === 'external' && f.external && f.external.url) return withHttps(f.external.url)
+    if (f.type === 'file' && f.file && f.file.url) return f.file.url
+  }
+  if (avatarProp && avatarProp.url) return withHttps(avatarProp.url)
+  return getFavicon(siteUrl)
+}
+
+// Notion request with timeout + retries
+async function notion(path, init = {}, { timeout = 10000, retries = 2 } = {}) {
+  if (!NOTION_TOKEN) throw new Error('Missing NOTION_TOKEN')
+  let lastErr
+  for (let i = 0; i <= retries; i++) {
+    const ac = new AbortController()
+    const timer = setTimeout(() => ac.abort('timeout'), timeout)
+    try {
+      const res = await fetch('https://api.notion.com/v1' + path, {
+        ...init,
+        headers: {
+          'Authorization': 'Bearer ' + NOTION_TOKEN,
+          'Notion-Version': NOTION_VERSION,
+          'Content-Type': 'application/json',
+          ...(init.headers || {})
+        },
+        signal: ac.signal
+      })
+      clearTimeout(timer)
+      if (!res.ok) {
+        const txt = await res.text()
+        if ((res.status === 429 || res.status >= 500) && i < retries) {
+          await new Promise(r => setTimeout(r, 400 * (i + 1)))
+          continue
+        }
+        throw new Error('Notion ' + res.status + ': ' + txt)
+      }
+      return await res.json()
+    } catch (e) {
+      clearTimeout(timer)
+      lastErr = e
+      if (i < retries) {
+        await new Promise(r => setTimeout(r, 400 * (i + 1)))
+        continue
+      }
+      throw lastErr
+    }
+  }
+}
+
+export async function getLinksAndCategories() {
+  const db = await notion('/databases/' + DB_ID)
+
+  const opt = (db.properties && (
+    (db.properties.Category && db.properties.Category.select && db.properties.Category.select.options) ||
+    (db.properties.Category && db.properties.Category.multi_select && db.properties.Category.multi_select.options)
+  )) || []
+  const optionOrder = opt.map(o => o.name)
+
+  const statusKey = ['Status', '\u72b6\u6001', 'Visible', '\u53d1\u5e03', 'Published', '\u516c\u5f00'].find(k => db.properties && db.properties[k])
+  const filter = statusKey ? {
+    or: [
+      { property: statusKey, select: { equals: '\u6b63\u5e38' } },
+      { property: statusKey, select: { equals: 'Normal' } },
+      { property: statusKey, select: { equals: 'Published' } },
+      { property: statusKey, select: { equals: '\u516c\u5f00' } }
+    ]
+  } : undefined
+
+  const sorts = []
+  if (db.properties && db.properties.Weight) sorts.push({ property: 'Weight', direction: 'descending' })
+  if (db.properties && db.properties.Name)   sorts.push({ property: 'Name',   direction: 'ascending'  })
+
+  const items = []
+  let start_cursor, has_more = true
+
+  while (has_more) {
+    const body = { page_size: 100, start_cursor }
+    if (filter) body.filter = filter
+    if (sorts.length) body.sorts = sorts
+
+    const data = await notion('/databases/' + DB_ID + '/query', { method: 'POST', body: JSON.stringify(body) })
+
+    for (const page of data.results) {
+      const p = page.properties
+      const pName = pick(p, ['Name', '\u540d\u79f0', '\u6807\u9898'])
+      const pURL  = pick(p, ['URL', 'Link', '\u94fe\u63a5'])
+      const pDesc = pick(p, ['Description', '\u63cf\u8ff0', '\u7b80\u4ecb', 'Desc'])
+      const pAvat = pick(p, ['Avatar', 'Icon', '\u56fe\u6807'])
+      const pCat  = pick(p, ['Category', '\u5206\u7c7b'])
+      const pW    = pick(p, ['Weight', '\u6743\u91cd'])
+      const pLang = pick(p, ['Language', '\u8bed\u8a00'])
+      const pRSS  = pick(p, ['RSS'])
+
+      const site   = withHttps(url(pURL))
+      const avatar = resolveAvatar(pAvat, site)
+
+      const cats = []
+      if (pCat && pCat.multi_select) cats.push(...pCat.multi_select.map(s => s.name))
+      else if (pCat && pCat.select)  cats.push(pCat.select.name)
+
+      items.push({
+        Name: t(pName),
+        URL: site,
+        Avatar: avatar,
+        Logo: avatar,
+        Description: rich(pDesc),
+        Categories: cats,
+        Weight: num(pW),
+        Language: sel(pLang),
+        RSS: withHttps(url(pRSS))
+      })
+    }
+
+    has_more = data.has_more
+    start_cursor = data.next_cursor
+  }
+
+  const used = Array.from(new Set(items.flatMap(i => i.Categories || []).filter(Boolean)))
+  let categories = optionOrder.filter(n => used.includes(n))
+  for (const c of used) if (!categories.includes(c)) categories.push(c)
+  if (items.some(i => !(i.Categories && i.Categories.length))) categories = [...categories, '\u672a\u5206\u7c7b']
+
+  return { items, categories }
+}

--- a/pages/links.js
+++ b/pages/links.js
@@ -1,0 +1,85 @@
+// /pages/links.js
+import { getLinksAndCategories } from '../lib/links'
+
+function LinksBody({ data = [], categories = [] }) {
+  const groups = (categories || []).map(cat => ({
+    cat,
+    items: (data || [])
+      .filter(x => (cat === '\u672a\u5206\u7c7b'
+        ? !(x.Categories && x.Categories.length)
+        : (x.Categories && x.Categories.includes(cat))
+      ))
+      .sort((a, b) => ((b.Weight || 0) - (a.Weight || 0)) || a.Name.localeCompare(b.Name))
+  }))
+
+  return (
+    <div style={{ maxWidth: 1100, margin: '0 auto', padding: '40px 16px' }}>
+      <h1 style={{ fontSize: 28, fontWeight: 700, margin: '0 0 12px' }}>\u53cb\u60c5\u94fe\u63a5</h1>
+
+      {(!data || data.length === 0) ? (
+        <div style={{ opacity: 0.7 }}>\u6682\u65e0\u6570\u636e\u3002\u8bf7\u68c0\u67e5 Notion \u5e93\u6388\u6743\u4e0e\u5b57\u6bb5\uff08Name / URL / Category\uff09\u3002</div>
+      ) : (
+        <div style={{ display: 'grid', gap: 40 }}>
+          {groups.map(({ cat, items }) => (
+            <section key={cat}>
+              <h2 style={{ fontSize: 20, fontWeight: 600, margin: '0 0 12px' }}>{cat}</h2>
+              {items.length === 0 ? (
+                <div style={{ opacity: 0.6, fontSize: 14 }}>\u6b64\u5206\u7c7b\u6682\u65e0\u6761\u76ee</div>
+              ) : (
+                <ul style={{
+                  listStyle: 'none', padding: 0, margin: 0,
+                  display: 'grid', gap: 16,
+                  gridTemplateColumns: 'repeat(auto-fill, minmax(260px, 1fr))'
+                }}>
+                  {items.map(it => (
+                    <li key={cat + '-' + it.URL} style={{ border: '1px solid #e5e7eb', borderRadius: 16, padding: 14 }}>
+                      <a
+                        href={it.URL}
+                        target="_blank"
+                        rel="noopener noreferrer nofollow external"
+                        style={{ display: 'flex', alignItems: 'center', gap: 12, textDecoration: 'none', cursor: 'pointer' }}
+                        onClick={e => e.stopPropagation()}
+                      >
+                        <img
+                          src={(it.Logo || it.Avatar)}
+                          alt={it.Name}
+                          loading="lazy"
+                          style={{ width: 40, height: 40, borderRadius: 8, objectFit: 'cover' }}
+                          onError={e => {
+                            try {
+                              const u = new URL(it.URL)
+                              e.currentTarget.src = 'https://icons.duckduckgo.com/ip3/' + u.hostname + '.ico'
+                            } catch {
+                              e.currentTarget.src = '/favicon.ico'
+                            }
+                          }}
+                        />
+                        <div>
+                          <div style={{ fontWeight: 600 }}>{it.Name}</div>
+                          <div style={{ opacity: 0.7, fontSize: 12, marginTop: 2 }}>{it.Description}</div>
+                        </div>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function LinksPage(props) {
+  return <LinksBody data={props.items} categories={props.categories} />
+}
+
+export async function getStaticProps() {
+  try {
+    const { items, categories } = await getLinksAndCategories()
+    return { props: { items, categories }, revalidate: 600 }
+  } catch (e) {
+    return { props: { items: [], categories: [] }, revalidate: 300 }
+  }
+}


### PR DESCRIPTION
- Add lib/links.js: fetches friends links from Notion database with retry logic, favicon fallback via DuckDuckGo, and auto https:// prefix
- Add pages/links.js: renders link cards in category groups, opens links in new tab, falls back to domain favicon on image error

https://claude.ai/code/session_012kAs7ujNtyQ4zV3Gn4cSBM

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
