### PR TITLE
Remove Avatar field usage and upgrade links page

### DIFF
--- a/pages/links.js
+++ b/pages/links.js
@@ -1,11 +1,98 @@
 // /pages/links.js
-import { getLinksAndCategories } from '../lib/links'
+import Head from 'next/head'
+import BLOG from '@/blog.config'
+import { siteConfig } from '@/lib/config'
+import { getGlobalData } from '@/lib/db/getSiteData'
+import { DynamicLayout } from '@/themes/theme'
+import { getLinksAndCategories } from '@/lib/links'
+import { useState, useEffect } from 'react'
 
+/* ---------- URL 规范化 ---------- */
+function normalizeUrl(u) {
+  if (!u) return ''
+  let s = String(u).trim()
+  s = s.replace(/[)\]\}，。；、？！,.;:]+$/g, '')
+  if (!/^https?:\/\//i.test(s)) s = 'https://' + s.replace(/^\/+/, '')
+  return s
+}
+
+function safeHost(u) {
+  try { return new URL(normalizeUrl(u)).hostname.toLowerCase() } catch { return '' }
+}
+
+/* ---------- 图标获取：并发竞速各类 favicon ---------- */
+function IconRace({ url, name }) {
+  const host = safeHost(url)
+  const nameInitial = (name || '').trim().charAt(0)
+  const hostInitial = (host || '').charAt(0)
+  const initial = (nameInitial || hostInitial || 'L').toUpperCase()
+  const letter = `data:image/svg+xml;charset=utf-8,<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%"><rect width="100%" height="100%" fill="#888"/><text x="50%" y="50%" font-size="32" text-anchor="middle" fill="white" dy=".3em">${initial}</text></svg>`
+
+  const [src, setSrc] = useState(letter)
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return
+    const els = []
+    const add = h => {
+      if (!h) return
+      const dns = document.createElement('link'); dns.rel = 'dns-prefetch'; dns.href = '//' + h
+      const pre = document.createElement('link'); pre.rel = 'preconnect'; pre.href = 'https://' + h; pre.crossOrigin = ''
+      document.head.appendChild(dns); document.head.appendChild(pre)
+      els.push(dns, pre)
+    }
+    add(host)
+    return () => { els.forEach(e => { try { document.head.removeChild(e) } catch {} }) }
+  }, [host])
+
+  useEffect(() => {
+    let settled = false
+    const imgs = []
+    const done = (u) => { if (!settled) { settled = true; setSrc(u) } }
+
+    const startRace = () => {
+      const candidates = []
+      if (host) {
+        candidates.push(
+          `https://${host}/favicon.ico`,
+          `https://${host}/apple-touch-icon.png`,
+          `https://${host}/favicon.png`,
+          `https://www.google.com/s2/favicons?sz=64&domain=${host}`,
+          `https://icons.duckduckgo.com/ip3/${host.replace(/^www\./, '')}.ico`
+        )
+      }
+      for (const u of candidates) {
+        const im = new Image()
+        im.decoding = 'async'
+        im.referrerPolicy = 'no-referrer'
+        im.onload = () => done(u)
+        im.onerror = () => {}
+        im.src = u
+        imgs.push(im)
+      }
+    }
+    startRace()
+    const cap = setTimeout(() => { if (!settled) done(letter) }, 2200)
+    return () => { settled = true; clearTimeout(cap); imgs.forEach(i => { i.onload = null; i.onerror = null }) }
+  }, [url, name])
+
+  return (
+    <img
+      src={src}
+      alt={name}
+      loading="lazy"
+      decoding="async"
+      referrerPolicy="no-referrer"
+      style={{ width: '100%', height: '100%', display: 'block', objectFit: 'cover' }}
+    />
+  )
+}
+
+/* ---------- 链接列表主体 ---------- */
 function LinksBody({ data = [], categories = [] }) {
   const groups = (categories || []).map(cat => ({
     cat,
     items: (data || [])
-      .filter(x => (cat === '\u672a\u5206\u7c7b'
+      .filter(x => (cat === '未分类'
         ? !(x.Categories && x.Categories.length)
         : (x.Categories && x.Categories.includes(cat))
       ))
@@ -14,17 +101,17 @@ function LinksBody({ data = [], categories = [] }) {
 
   return (
     <div style={{ maxWidth: 1100, margin: '0 auto', padding: '40px 16px' }}>
-      <h1 style={{ fontSize: 28, fontWeight: 700, margin: '0 0 12px' }}>\u53cb\u60c5\u94fe\u63a5</h1>
+      <h1 style={{ fontSize: 28, fontWeight: 700, margin: '0 0 12px' }}>友情链接</h1>
 
       {(!data || data.length === 0) ? (
-        <div style={{ opacity: 0.7 }}>\u6682\u65e0\u6570\u636e\u3002\u8bf7\u68c0\u67e5 Notion \u5e93\u6388\u6743\u4e0e\u5b57\u6bb5\uff08Name / URL / Category\uff09\u3002</div>
+        <div style={{ opacity: 0.7 }}>暂无数据。请检查 Notion 库授权与字段（Name / URL / Category）。</div>
       ) : (
         <div style={{ display: 'grid', gap: 40 }}>
           {groups.map(({ cat, items }) => (
             <section key={cat}>
               <h2 style={{ fontSize: 20, fontWeight: 600, margin: '0 0 12px' }}>{cat}</h2>
               {items.length === 0 ? (
-                <div style={{ opacity: 0.6, fontSize: 14 }}>\u6b64\u5206\u7c7b\u6682\u65e0\u6761\u76ee</div>
+                <div style={{ opacity: 0.6, fontSize: 14 }}>此分类暂无条目</div>
               ) : (
                 <ul style={{
                   listStyle: 'none', padding: 0, margin: 0,
@@ -34,26 +121,15 @@ function LinksBody({ data = [], categories = [] }) {
                   {items.map(it => (
                     <li key={cat + '-' + it.URL} style={{ border: '1px solid #e5e7eb', borderRadius: 16, padding: 14 }}>
                       <a
-                        href={it.URL}
+                        href={normalizeUrl(it.URL)}
                         target="_blank"
                         rel="noopener noreferrer nofollow external"
                         style={{ display: 'flex', alignItems: 'center', gap: 12, textDecoration: 'none', cursor: 'pointer' }}
                         onClick={e => e.stopPropagation()}
                       >
-                        <img
-                          src={(it.Logo || it.Avatar)}
-                          alt={it.Name}
-                          loading="lazy"
-                          style={{ width: 40, height: 40, borderRadius: 8, objectFit: 'cover' }}
-                          onError={e => {
-                            try {
-                              const u = new URL(it.URL)
-                              e.currentTarget.src = 'https://icons.duckduckgo.com/ip3/' + u.hostname + '.ico'
-                            } catch {
-                              e.currentTarget.src = '/favicon.ico'
-                            }
-                          }}
-                        />
+                        <div style={{ width: 40, height: 40, borderRadius: 8, overflow: 'hidden', flexShrink: 0 }}>
+                          <IconRace url={it.URL} name={it.Name} />
+                        </div>
                         <div>
                           <div style={{ fontWeight: 600 }}>{it.Name}</div>
                           <div style={{ opacity: 0.7, fontSize: 12, marginTop: 2 }}>{it.Description}</div>
@@ -71,15 +147,60 @@ function LinksBody({ data = [], categories = [] }) {
   )
 }
 
-export default function LinksPage(props) {
-  return <LinksBody data={props.items} categories={props.categories} />
+/* ---------- 页面导出：标题 & 预连接 ---------- */
+export default function Links(props) {
+  const theme = siteConfig('THEME', BLOG.THEME, props?.NOTION_CONFIG)
+  const siteTitle = siteConfig('TITLE', BLOG.TITLE, props?.NOTION_CONFIG) || BLOG?.TITLE || 'Site'
+  const pageTitle = `${siteTitle} | Links`
+
+  useEffect(() => {
+    if (props.__hasSlug && typeof document !== 'undefined') {
+      document.documentElement.classList.add('__links_hide_notion')
+      return () => document.documentElement.classList.remove('__links_hide_notion')
+    }
+  }, [props.__hasSlug])
+
+  const body = <LinksBody data={props.items} categories={props.categories} />
+
+  return (
+    <>
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
+      {props.__hasSlug
+        ? <DynamicLayout theme={theme} layoutName="LayoutSlug" {...props}>{body}</DynamicLayout>
+        : body}
+    </>
+  )
 }
 
-export async function getStaticProps() {
+/* ---------- ISR & 占位页探测 ---------- */
+export async function getStaticProps({ locale }) {
+  let base = {}
+  let items = []
+  let categories = []
+  let hasSlug = false
+
   try {
-    const { items, categories } = await getLinksAndCategories()
-    return { props: { items, categories }, revalidate: 600 }
+    base = await getGlobalData({ from: 'links', locale })
+    const pages = base?.allPages || base?.pages || []
+    hasSlug = Array.isArray(pages) && pages.some(p =>
+      (p?.slug === 'links' || p?.slug?.value === 'links') &&
+      (p?.type === 'Page' || p?.type?.value === 'Page') &&
+      (p?.status === 'Published' || p?.status?.value === 'Published' || p?.status === '公开' || p?.status === '已发布')
+    )
   } catch (e) {
-    return { props: { items: [], categories: [] }, revalidate: 300 }
+    base = { NOTION_CONFIG: base?.NOTION_CONFIG || {} }
   }
+
+  try {
+    const r = await getLinksAndCategories({ debug: false })
+    items = r?.items || []
+    categories = r?.categories || []
+  } catch (e) {
+    items = []
+    categories = []
+  }
+
+  return { props: { ...base, items, categories, __hasSlug: hasSlug }, revalidate: 120 } // 页面2分钟刷新一次
 }

--- a/pages/links.js
+++ b/pages/links.js
@@ -2,7 +2,7 @@
 import Head from 'next/head'
 import BLOG from '@/blog.config'
 import { siteConfig } from '@/lib/config'
-import { getGlobalData } from '@/lib/db/getSiteData'
+import { fetchGlobalAllData } from '@/lib/db/SiteDataApi'
 import { DynamicLayout } from '@/themes/theme'
 import { getLinksAndCategories } from '@/lib/links'
 import { useState, useEffect } from 'react'
@@ -182,7 +182,7 @@ export async function getStaticProps({ locale }) {
   let hasSlug = false
 
   try {
-    base = await getGlobalData({ from: 'links', locale })
+    base = await fetchGlobalAllData({ from: 'links', locale })
     const pages = base?.allPages || base?.pages || []
     hasSlug = Array.isArray(pages) && pages.some(p =>
       (p?.slug === 'links' || p?.slug?.value === 'links') &&


### PR DESCRIPTION
- Remove it.Avatar fallback from icon display; icons now resolved entirely via IconRace favicon-racing logic (no Notion Avatar field)
- Add normalizeUrl / safeHost URL utilities
- Add IconRace component: concurrently races favicon.ico, apple-touch-icon, Google S2 and DuckDuckGo favicon APIs, falls back to SVG letter avatar after 2.2 s timeout
- Integrate DynamicLayout theme system and getGlobalData for slug detection
- Update getStaticProps error handling and set revalidate to 120 s

https://claude.ai/code/session_01BYzLh8Rm6PLG7r3XnTVw9v

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
