### PR TITLE
fix: resolve missing module error in pages/links.js

### DIFF
--- a/pages/links.js
+++ b/pages/links.js
@@ -2,7 +2,7 @@
 import Head from 'next/head'
 import BLOG from '@/blog.config'
 import { siteConfig } from '@/lib/config'
-import { getGlobalData } from '@/lib/db/getSiteData'
+import { fetchGlobalAllData } from '@/lib/db/SiteDataApi'
 import { DynamicLayout } from '@/themes/theme'
 import getLinksAndCategories from '@/lib/links'
 import { useRef, useState, useEffect } from 'react'
@@ -454,7 +454,7 @@ export async function getStaticProps({ locale }) {
   let hasSlug = false
 
   try {
-    base = await getGlobalData({ from: 'links', locale })
+    base = await fetchGlobalAllData({ from: 'links', locale })
     const pages = base?.allPages || base?.pages || []
     hasSlug = Array.isArray(pages) && pages.some(p =>
       (p?.slug === 'links' || p?.slug?.value === 'links') &&


### PR DESCRIPTION
Replace non-existent import `getGlobalData` from `@/lib/db/getSiteData` with `fetchGlobalAllData` from `@/lib/db/SiteDataApi`, which is the correct module used by all other pages in this project.

https://claude.ai/code/session_01HpriNuqZEVSMLBLpqpT2JP

> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
