### PR TITLE
feat(hexo): refresh homepage hero with Chrome-inspired UI style

### DIFF
--- a/themes/hexo/components/Hero.js
+++ b/themes/hexo/components/Hero.js
@@ -59,14 +59,15 @@ const Hero = props => {
     <header
       id='header'
       style={{ zIndex: 1 }}
-      className='w-full h-screen relative bg-black'>
-      <div className='text-white absolute bottom-0 flex flex-col h-full items-center justify-center w-full '>
+      className='w-full h-screen relative overflow-hidden bg-[#f8fbff]'>
+      <div className='text-slate-900 absolute bottom-0 flex flex-col h-full items-center justify-center w-full px-6'>
+        <div className='hero-content-panel w-full max-w-5xl rounded-[2rem] px-8 py-10 md:px-14 md:py-16'>
         {/* 站点标题 */}
-        <div className='font-black text-4xl md:text-5xl shadow-text'>
+        <div className='font-black text-4xl md:text-6xl tracking-tight text-center'>
           {siteInfo?.title || siteConfig('TITLE')}
         </div>
         {/* 站点欢迎语 */}
-        <div className='mt-2 h-12 items-center text-center font-medium shadow-text text-lg'>
+        <div className='mt-4 h-12 items-center text-center font-medium text-lg text-slate-600'>
           <span id='typed' />
         </div>
 
@@ -74,11 +75,12 @@ const Hero = props => {
         {siteConfig('HEXO_HOME_NAV_BUTTONS', null, CONFIG) && (
           <NavButtonGroup {...props} />
         )}
+        </div>
 
         {/* 滚动按钮 */}
         <div
           onClick={scrollToWrapper}
-          className='z-10 cursor-pointer w-full text-center py-4 text-3xl absolute bottom-10 text-white'>
+          className='z-10 cursor-pointer w-full text-center py-4 text-3xl absolute bottom-10 text-slate-500'>
           <div className='opacity-70 animate-bounce text-xs'>
             {siteConfig('HEXO_SHOW_START_READING', null, CONFIG) &&
               locale.COMMON.START_READING}
@@ -91,7 +93,7 @@ const Hero = props => {
         id='header-cover'
         alt={siteInfo?.title}
         src={siteInfo?.pageCover}
-        className={`header-cover w-full h-screen object-cover object-center ${siteConfig('HEXO_HOME_NAV_BACKGROUND_IMG_FIXED', null, CONFIG) ? 'fixed' : ''}`}
+        className={`header-cover w-full h-screen object-cover object-center opacity-20 ${siteConfig('HEXO_HOME_NAV_BACKGROUND_IMG_FIXED', null, CONFIG) ? 'fixed' : ''}`}
       />
     </header>
   )

--- a/themes/hexo/components/NavButtonGroup.js
+++ b/themes/hexo/components/NavButtonGroup.js
@@ -12,7 +12,7 @@ const NavButtonGroup = (props) => {
   }
 
   return (
-    <nav id='home-nav-button' className={'w-full z-10 md:h-72 md:mt-6 xl:mt-32 px-5 py-2 mt-8 flex flex-wrap md:max-w-6xl space-y-2 md:space-y-0 md:flex justify-center max-h-80 overflow-auto'}>
+    <nav id='home-nav-button' className={'w-full z-10 md:mt-8 px-2 py-2 mt-8 flex flex-wrap md:max-w-5xl gap-3 justify-center max-h-80 overflow-auto'}>
       {categoryOptions?.map(category => {
         return (
           <SmartLink
@@ -20,7 +20,7 @@ const NavButtonGroup = (props) => {
             title={`${category.name}`}
             href={`/category/${category.name}`}
             passHref
-            className='text-center shadow-text w-full sm:w-4/5 md:mx-6 md:w-40 md:h-14 lg:h-20 h-14 justify-center items-center flex border-2 cursor-pointer rounded-lg glassmorphism hover:bg-white hover:text-black duration-200 hover:scale-105 transform'>
+            className='text-center w-full sm:w-4/5 md:w-auto px-6 h-12 justify-center items-center flex border border-[#d2e3fc] cursor-pointer rounded-full bg-white/95 text-[#1967d2] font-semibold hover:bg-[#e8f0fe] hover:border-[#8ab4f8] duration-200'>
                {category.name}
             </SmartLink>
         )

--- a/themes/hexo/style.js
+++ b/themes/hexo/style.js
@@ -194,13 +194,18 @@ const Style = () => {
         width: 100%;
         height: 100%;
         background: linear-gradient(
-          to bottom,
-          rgba(0, 0, 0, 0.5) 0%,
-          rgba(0, 0, 0, 0.2) 10%,
-          rgba(0, 0, 0, 0) 25%,
-          rgba(0, 0, 0, 0.2) 75%,
-          rgba(0, 0, 0, 0.5) 100%
+          180deg,
+          rgba(248, 251, 255, 0.92) 0%,
+          rgba(248, 251, 255, 0.65) 48%,
+          rgba(248, 251, 255, 0.92) 100%
         );
+      }
+
+      #theme-hexo .hero-content-panel {
+        background: rgba(255, 255, 255, 0.78);
+        border: 1px solid rgba(210, 227, 252, 0.95);
+        box-shadow: 0 14px 50px rgba(32, 33, 36, 0.12);
+        backdrop-filter: blur(12px);
       }
 
       /* Custem */


### PR DESCRIPTION
### Motivation
- 将 Hexo 主题首页首屏视觉从深色沉浸式改为更接近 Google Chrome 中文官网的明亮、留白与品牌蓝风格，以提升可读性与现代感。

### Description
- 在 `themes/hexo/components/Hero.js` 中重构首屏容器和层级，加入半透明玻璃质感的内容面板、调整标题字体大小与行距并降低背景图可见度以突出前景内容。
- 在 `themes/hexo/components/NavButtonGroup.js` 中将分类导航按钮改为圆角胶囊样式，采用白底 + 蓝字 + 浅蓝 hover 效果以符合 Chrome 风格交互语言。
- 在 `themes/hexo/style.js` 中更新 hero 背景蒙层渐变为浅亮色系并新增 `.hero-content-panel` 的边框、阴影与模糊滤镜样式以增强可读性与细节质感。

### Testing
- 运行了代码风格检查 `npm run -s lint`，该命令暴露了仓库中大量历史的 lint 问题与类型错误，但这些问题与本次修改的三个文件无关，因此 lint 未通过（失败，非因本次改动）。
- 本次变更仅涉及 `themes/hexo/components/Hero.js`、`themes/hexo/components/NavButtonGroup.js` 和 `themes/hexo/style.js` 三个文件的样式/结构调整，已在本地确认文件变更正确。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03f0d557ec832ebeb6f1f2f579d2f3)