### PR TITLE
Fix pages/recommend/index.js syntax and data import to resolve Next.js build errors

### DIFF
--- a/pages/recommend/index.js
+++ b/pages/recommend/index.js
@@ -1,28 +1,28 @@
 // pages/recommend/index.js
 import BLOG from '@/blog.config'
 import { siteConfig } from '@/lib/config'
-import { getGlobalData } from '@/lib/db/getSiteData'
+import { fetchGlobalAllData } from '@/lib/db/SiteDataApi'
 import { DynamicLayout } from '@/themes/theme'
-import Head from 'next/head' // 引入 Head 组件
+import Head from 'next/head'
 import { useEffect } from 'react'
 
-export 默认 function LayoutRecommend(props) {
+export default function LayoutRecommend(props) {
   useEffect(() => {
     // 设置页面标题为 SoMic Studio | Hots，防止被覆盖
-    document.title = 'SoMic Studio | Hots';
+    document.title = 'SoMic Studio | Hots'
 
     // 确保后续代码不会修改标题
-    const originalTitle = document.title;
+    const originalTitle = document.title
     const intervalId = setInterval(() => {
       // 如果标题被修改为 "loading"，则恢复为原始标题
       if (document.title === 'SoMic Studio | loading') {
-        document.title = originalTitle;
+        document.title = originalTitle
       }
-    }， 100); // 每100ms检查一次标题
+    }, 100)
 
     // 清理 setInterval，避免内存泄漏
-    return () => clearInterval(intervalId);
-  }， []); // 空依赖数组，确保只在组件挂载时执行
+    return () => clearInterval(intervalId)
+  }, [])
 
   return (
     <>
@@ -33,26 +33,28 @@ export 默认 function LayoutRecommend(props) {
 
       {/* 渲染页面的内容 */}
       <DynamicLayout
-        theme={siteConfig('THEME', BLOG.THEME, props。NOTION_CONFIG)}
-        layoutName="LayoutRecommend"
-        {。。。props}
+        theme={siteConfig('THEME', BLOG.THEME, props.NOTION_CONFIG)}
+        layoutName='LayoutRecommend'
+        {...props}
       />
     </>
-  );
+  )
 }
 
 export async function getStaticProps({ locale }) {
-  const props = await getGlobalData({ from: 'Recommend', locale })
+  const props = await fetchGlobalAllData({ from: 'Recommend', locale })
 
   // ✅ 兜底：如果 posts 为空，就从 allPages 抽出已发布的博文
-  if ((!props.posts || props.posts.length === 0) && Array。isArray(props。allPages)) {
-    props。posts = props。allPages。filter(p => p?.输入 === 'Post' && p?.status === 'Published')
+  if ((!props.posts || props.posts.length === 0) && Array.isArray(props.allPages)) {
+    props.posts = props.allPages.filter(
+      p => p?.type === 'Post' && p?.status === 'Published'
+    )
   }
 
   return {
-    props，
+    props,
     revalidate: process.env.EXPORT
       ? undefined
-      : siteConfig('NEXT_REVALIDATE_SECOND', BLOG.NEXT_REVALIDATE_SECOND, props。NOTION_CONFIG)
+      : siteConfig('NEXT_REVALIDATE_SECOND', BLOG.NEXT_REVALIDATE_SECOND, props.NOTION_CONFIG)
   }
 }


### PR DESCRIPTION
### Motivation
- The recommend page contained invalid JavaScript/JSX tokens and Chinese punctuation that caused a parser/type-check failure during `next build`.
- The file imported a nonexistent module `@/lib/db/getSiteData`, causing a module-not-found error during compilation.

### Description
- Fixed syntax issues in `pages/recommend/index.js` (corrected `export default`, removed Chinese punctuation, fixed spread usage and other invalid tokens) so the file is valid JavaScript/JSX.
- Replaced the broken import with `fetchGlobalAllData` from `@/lib/db/SiteDataApi` and updated `getStaticProps` to call `fetchGlobalAllData` instead of the missing function.
- Preserved the page behavior (explicit title override and fallback post filtering) while making the file compile-safe.

### Testing
- Ran `yarn run build`, and the previous syntax and module-not-found errors are resolved (build advances past the compile step).
- Full build still fails later due to external Notion network/DNS errors (`getaddrinfo EAI_AGAIN www.notion.so`), which are environment-dependent and unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03f67360e0832eb3badc1e68d6a7f3)