### PR TITLE
Fix Notion page id collection fallback

### DIFF
--- a/lib/db/notion/getAllPageIds.js
+++ b/lib/db/notion/getAllPageIds.js
@@ -1,35 +1,49 @@
-import BLOG from "@/blog.config"
+import BLOG from '@/blog.config'
 
 export default function getAllPageIds(collectionQuery, collectionId, collectionView, viewIds) {
   if (!collectionQuery && !collectionView) {
     return []
   }
+
   let pageIds = []
+
   try {
-    // Notion数据库中的第几个视图用于站点展示和排序：
+    // Notion 数据库中的第几个视图用于站点展示和排序：
     const groupIndex = BLOG.NOTION_INDEX || 0
-    if (viewIds && viewIds.length > 0) {
-      const ids = collectionQuery[collectionId][viewIds[groupIndex]]?.collection_group_results?.blockIds || []
-      if (ids) {
-        for (const id of ids) {
-          pageIds.push(id)
-        }
+    if (Array.isArray(viewIds) && viewIds.length > 0) {
+      const viewId = viewIds[groupIndex] || viewIds[0]
+      const queryView = collectionQuery?.[collectionId]?.[viewId]
+      const ids =
+        queryView?.collection_group_results?.blockIds ||
+        queryView?.blockIds ||
+        []
+
+      if (Array.isArray(ids)) {
+        pageIds.push(...ids.filter(Boolean))
       }
     }
   } catch (error) {
-    console.error('Error fetching page IDs:', ids, error);
-    return [];
+    // 不能在 catch 中引用 try 代码块内部的 ids，否则会把真实异常覆盖成
+    // ReferenceError: ids is not defined，导致 Vercel 构建阶段无法定位问题。
+    console.error('Error fetching page IDs:', error)
   }
 
   // 否则按照数据库原始排序
-  if (pageIds.length === 0 && collectionQuery && Object.values(collectionQuery).length > 0) {
+  if (
+    pageIds.length === 0 &&
+    collectionQuery &&
+    collectionId &&
+    collectionQuery[collectionId] &&
+    Object.values(collectionQuery[collectionId]).length > 0
+  ) {
     const pageSet = new Set()
     Object.values(collectionQuery[collectionId]).forEach(view => {
-      view?.blockIds?.forEach(id => pageSet.add(id)) // group视图
-      view?.collection_group_results?.blockIds?.forEach(id => pageSet.add(id)) // table视图
+      view?.blockIds?.forEach(id => id && pageSet.add(id)) // group 视图
+      view?.collection_group_results?.blockIds?.forEach(id => id && pageSet.add(id)) // table 视图
     })
     pageIds = [...pageSet]
-    // console.log('PageIds: 从collectionQuery获取', collectionQuery, pageIds.length)
+    // console.log('PageIds: 从 collectionQuery 获取', collectionQuery, pageIds.length)
   }
-  return pageIds
+
+  return pageIds.filter(id => typeof id === 'string' && id)
 }


### PR DESCRIPTION
> 尽量按此模板PR内容，或粘贴相关的ISSUE链接。

## 已知问题

1. (示例)版本号管理不规范
   - 版本号直接写在环境变量中，容易出错
   - 多处维护版本号，可能不一致

## 解决方案

1. (示例)将版本号管理从 `.env.local` 迁移到 `package.json`
   - 统一从 `package.json` 读取版本号
   - 使用 IIFE 优雅处理版本号获取逻辑
   - 保持向后兼容，支持环境变量覆盖

## 改动收益

1. (示例)更规范的版本管理
   - 统一从 `package.json` 读取
   - 保持与 npm 生态一致
   - 减少人为错误

## 具体改动

1. （示例）`blog.config.js`
   - 移除原有的静态版本号配置
   - 在文件末尾添加动态版本号获取逻辑
   - 保持向后兼容，优先使用环境变量
   - 添加错误处理和默认值

## 测试确认

- [x] 本地开发环境测试通过
- [x] 生产环境构建测试通过
- [x] 版本号正确显示
- [x] 环境变量配置正常工作
